### PR TITLE
Add option to show selected path and app version in window title. And update version to 0.9.0 (it's time)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,5 +16,5 @@ set(SOURCE_FILES
     src/utils.c)
 
 include_directories(${GTK2_INCLUDE_DIRS} ${LIBXML2_INCLUDE_DIRS} . ${PROJECT_SOURCE_DIR})
-add_executable(gdmap_0_8_1 ${SOURCE_FILES})
-target_link_libraries(gdmap_0_8_1 ${GTK2_LIBRARIES} ${LIBXML2_LIBRARIES} m)
+add_executable(gdmap_0_9_0 ${SOURCE_FILES})
+target_link_libraries(gdmap_0_9_0 ${GTK2_LIBRARIES} ${LIBXML2_LIBRARIES} m)

--- a/config.h
+++ b/config.h
@@ -65,13 +65,13 @@
 #define PACKAGE_NAME "GdMap"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "GdMap 0.8.1"
+#define PACKAGE_STRING "GdMap 0.9.0"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "gdmap"
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "0.8.1"
+#define PACKAGE_VERSION "0.9.0"
 
 /* Define to 1 if you have the ANSI C header files. */
 #define STDC_HEADERS 1
@@ -83,7 +83,7 @@
 /* #undef TM_IN_SYS_TIME */
 
 /* Version number of package */
-#define VERSION "0.8.1"
+#define VERSION "0.9.0"
 
 /* Define to 1 if your processor stores words with the most significant byte
    first (like Motorola and SPARC, unlike Intel and VAX). */

--- a/src/about.c
+++ b/src/about.c
@@ -1,10 +1,10 @@
-/* Copyright (C) 2005-2008 sgop@users.sourceforge.net
- * This is free software distributed under the terms of the GNU Public
- * License.  See the file COPYING for details.
- */
-/* $Revision: 1.2 $
- * $Date: 2008/05/23 14:54:24 $
- * $Author: sgop $
+/*
+ * Copyright (C) 2005-2006 sgop@users.sourceforge.net
+ * Copyright (C) 2024 Raphael Rosch <gnome-dev@insaner.com>
+ * 
+ * This is free software
+ * distributed under the terms of the GNU Public License.  See the
+ * file COPYING for details.
  */
 
 #ifdef HAVE_CONFIG_H
@@ -37,6 +37,7 @@ void gui_show_about(GtkWindow* parent)
     GtkWidget* win;
     const char* authors[] = {
         "Markus Lausser <sgop@users.sourceforge.net>",
+        "Raphael Rosch <gnome-dev@insaner.com>",
         NULL
     };
     

--- a/src/gui_main.c
+++ b/src/gui_main.c
@@ -1016,7 +1016,7 @@ static void gui_set_window_title(const char* title)
 static void gui_update_window_title(void)
 {
     char* temp = "";
-    if (pref_get_show_path_in_title())
+    if (pref_get_show_path_in_title() && Folder != NULL)
         temp = g_strdup_printf("%s  —  ", Folder);
     
     temp = g_strdup_printf("%s %s", temp, AppDisplayName);

--- a/src/gui_main.c
+++ b/src/gui_main.c
@@ -429,6 +429,7 @@ void gui_tree_load_and_display(const char* folder)
     tree_t* tree = gui_tree_load(folder, 0);
     if (tree)
     {
+        Folder = folder;
         tree_info_t* info = tree_info_create(tree);
         gui_tree_display(info, TRUE, TRUE);
     }

--- a/src/gui_main.c
+++ b/src/gui_main.c
@@ -1,10 +1,10 @@
-/* Copyright (C) 2005 sgop@users.sourceforge.net This is free software
+/*
+ * Copyright (C) 2005-2006 sgop@users.sourceforge.net
+ * Copyright (C) 2024 Raphael Rosch <gnome-dev@insaner.com>
+ * 
+ * This is free software
  * distributed under the terms of the GNU Public License.  See the
  * file COPYING for details.
- */
-/* $Revision: 1.12 $
- * $Date: 2008/05/23 14:54:28 $
- * $Author: sgop $
  */
 
 #ifdef HAVE_CONFIG_H
@@ -432,6 +432,7 @@ void gui_tree_load_and_display(const char* folder)
         tree_info_t* info = tree_info_create(tree);
         gui_tree_display(info, TRUE, TRUE);
     }
+    gui_update_window_title();
 }
 
 
@@ -1007,6 +1008,26 @@ static GdkPixbuf* create_pixbuf(const gchar *filename)
     return pix;
 }
 
+static void gui_set_window_title(const char* title)
+{
+    gtk_window_set_title(GTK_WINDOW(MainWin), title);
+}
+
+static void gui_update_window_title(void)
+{
+    char* temp = "";
+    if (pref_get_show_path_in_title())
+        temp = g_strdup_printf("%s  —  ", Folder);
+    
+    temp = g_strdup_printf("%s %s", temp, AppDisplayName);
+
+    if (pref_get_show_version_in_title())
+        temp = g_strdup_printf("%s %s", temp, VERSION);
+    
+    gui_set_window_title(temp);
+    g_free(temp);
+}
+
 GtkWidget* gui_create_main_win(void)
 {
     GtkWidget* win;
@@ -1015,7 +1036,7 @@ GtkWidget* gui_create_main_win(void)
 
     win = gtk_window_new(GTK_WINDOW_TOPLEVEL);
     MainWin = win;
-    gtk_window_set_title(GTK_WINDOW(win), "Graphical Disk Map "VERSION);
+    gui_update_window_title();
     gtk_window_set_role(GTK_WINDOW(win), "Main window");
     gtk_window_set_default_icon(create_pixbuf("gdmap_icon.png"));
     gtk_window_set_default_size(GTK_WINDOW(win), 700, 450);
@@ -1058,6 +1079,7 @@ GtkWidget* gui_create_main_win(void)
     gtk_widget_show(win);
 
     pref_set_redraw_callback(gui_tree_redraw);
+    pref_set_window_title_callback(gui_update_window_title);
 
     return win;
 }

--- a/src/gui_main.h
+++ b/src/gui_main.h
@@ -16,6 +16,12 @@
 
 #include "tree.h"
 
+//static const char* Folder = NULL;
+extern const char* Folder;
+extern const char* AppDisplayName;
+
+static void gui_set_window_title(const char* title);
+static void gui_update_window_title(void);
 GtkWidget* gui_create_main_win (void);
 GtkWidget* gui_get_main_win();
 void gui_tree_load_and_display(const char* folder);

--- a/src/main.c
+++ b/src/main.c
@@ -1,10 +1,9 @@
-/* Copyright (C) 2005-2006 sgop@users.sourceforge.net
+/*
+ * Copyright (C) 2005-2006 sgop@users.sourceforge.net
+ * Copyright (C) 2024 Raphael Rosch <gnome-dev@insaner.com>
+ * 
  * This is free software distributed under the terms of the
  * GNU Public License.  See the file COPYING for details.
- */
-/* $Revision: 1.8 $
- * $Date: 2008/05/23 14:54:28 $
- * $Author: sgop $
  */
 
 #ifdef HAVE_CONFIG_H
@@ -21,6 +20,9 @@
 
 #define NL "\n"
 
+const char* AppDisplayName = "Graphical Disk Map";
+const char* Folder = NULL;
+
 static const char* GtkResource =
   "style \"event\" {"NL
   "  fg[NORMAL] = { 0, 0.5, 1.0 }"NL
@@ -28,8 +30,6 @@ static const char* GtkResource =
   "}"NL
   ""NL
   "widget \"*EventLabel*\" style \"event\""NL;
-
-static const char* Folder = NULL;
 
 static GOptionEntry Options[] = {
   { "folder", 'f', 0, G_OPTION_ARG_STRING, &Folder, "Inspect folder", "dir" },

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -13,12 +13,13 @@
 #define DISPLAY_STANDARD_CUSHION    0
 #define DISPLAY_SQUARE_CUSHION      1
 
-typedef void (*RedrawFunc)(void);
+typedef void (*Func_p)(void);
 
 /* extern gboolean LeaveDevice; */
 /* extern gboolean UseReportedSize; */
 
-void pref_set_redraw_callback(RedrawFunc func);
+void pref_set_window_title_callback(Func_p func);
+void pref_set_redraw_callback(Func_p func);
 void pref_init();
 
 unsigned pref_get_display_mode(void);


### PR DESCRIPTION
Added an option in the preferences menu to enable or disable the display of the software version, and more importantly, of the path that was selected with `-f`. That can later be expanded to enabling the display of the currently selected path.